### PR TITLE
Add LRU cache for parsed user agents

### DIFF
--- a/useragent_decoder.go
+++ b/useragent_decoder.go
@@ -66,22 +66,22 @@ func (ua *UserAgentDecoder) Init(config interface{}) (err error) {
 	return
 }
 
-func (ua *UserAgentDecoder) GetAgent(uaStr string) *uaparser.Client {
+func (ua *UserAgentDecoder) GetAgent(uaStr string) (*uaparser.Client, bool) {
 	var uaClient *uaparser.Client
 
 	if ua.CacheSize > 0 {
 		if val, ok := ua.cache.Get(uaStr); !ok {
 			uaClient = ua.parser.Parse(uaStr)
-			// TODO Track evictions
+			// TODO We should track cache evictions
 			ua.cache.Add(uaStr, uaClient)
 		} else {
-			uaClient = val.(*uaparser.Client)
+			return val.(*uaparser.Client), true
 		}
 	} else {
 		uaClient = ua.parser.Parse(uaStr)
 	}
 
-	return uaClient
+	return uaClient, false
 }
 
 func (ua *UserAgentDecoder) Decode(pack *PipelinePack) (packs []*PipelinePack, err error) {
@@ -95,7 +95,8 @@ func (ua *UserAgentDecoder) Decode(pack *PipelinePack) (packs []*PipelinePack, e
 	}
 
 	if ua.parser != nil {
-		uaClient := ua.GetAgent(agentStr)
+		// TODO Track cache hits/misses
+		uaClient, _ := ua.GetAgent(agentStr)
 
 		var nf *message.Field
 

--- a/useragent_decoder_test.go
+++ b/useragent_decoder_test.go
@@ -28,11 +28,12 @@ var (
 	}
 )
 
-func buildDecoder() *UserAgentDecoder {
+func buildDecoder(cacheSize int) *UserAgentDecoder {
 	decoder := new(UserAgentDecoder)
 	decoder.Init(&UserAgentDecoderConfig{
 		UserAgentFile: "uap-core/regexes.yaml",
 		SourceField:   "doesntmatter",
+		CacheSize:     cacheSize,
 	})
 
 	return decoder
@@ -42,39 +43,42 @@ func TestAgentParse(t *testing.T) {
 	// NOTE This is intentionally non-exhaustive as the upstream uaparser
 	// library has plenty of tests that verify the parsing.
 	agentStr := "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1"
-	decoder := buildDecoder()
 
-	agent := decoder.GetAgent(agentStr)
+	// Run once without a cache and once with a cache
 	var expected string
 	var result string
+	for _, v := range []int{0, 10} {
+		decoder := buildDecoder(v)
+		agent := decoder.GetAgent(agentStr)
 
-	expected = "Mobile Safari"
-	if result = agent.UserAgent.Family; expected != result {
-		t.Errorf("incorrect user agent family; expected '%s', got '%s'", expected, result)
-	}
-	expected = "9"
-	if result = agent.UserAgent.Major; expected != result {
-		t.Errorf("incorrect user agent major; expected '%s', got '%s'", expected, result)
-	}
-	expected = "0"
-	if result = agent.UserAgent.Minor; expected != result {
-		t.Errorf("incorrect user agent minor; expected '%s', got '%s'", expected, result)
-	}
-	expected = "iOS"
-	if result = agent.Os.Family; expected != result {
-		t.Errorf("incorrect os family; expected '%s', got '%s'", expected, result)
-	}
-	expected = "9"
-	if result = agent.Os.Major; expected != result {
-		t.Errorf("incorrect os major; expected '%s', got '%s'", expected, result)
-	}
-	expected = "1"
-	if result = agent.Os.Minor; expected != result {
-		t.Errorf("incorrect os minor; expected '%s', got '%s'", expected, result)
-	}
-	expected = "iPhone"
-	if result = agent.Device.Family; expected != result {
-		t.Errorf("incorrect device family; expected '%s', got '%s'", expected, result)
+		expected = "Mobile Safari"
+		if result = agent.UserAgent.Family; expected != result {
+			t.Errorf("incorrect user agent family; expected '%s', got '%s'", expected, result)
+		}
+		expected = "9"
+		if result = agent.UserAgent.Major; expected != result {
+			t.Errorf("incorrect user agent major; expected '%s', got '%s'", expected, result)
+		}
+		expected = "0"
+		if result = agent.UserAgent.Minor; expected != result {
+			t.Errorf("incorrect user agent minor; expected '%s', got '%s'", expected, result)
+		}
+		expected = "iOS"
+		if result = agent.Os.Family; expected != result {
+			t.Errorf("incorrect os family; expected '%s', got '%s'", expected, result)
+		}
+		expected = "9"
+		if result = agent.Os.Major; expected != result {
+			t.Errorf("incorrect os major; expected '%s', got '%s'", expected, result)
+		}
+		expected = "1"
+		if result = agent.Os.Minor; expected != result {
+			t.Errorf("incorrect os minor; expected '%s', got '%s'", expected, result)
+		}
+		expected = "iPhone"
+		if result = agent.Device.Family; expected != result {
+			t.Errorf("incorrect device family; expected '%s', got '%s'", expected, result)
+		}
 	}
 }
 

--- a/useragent_decoder_test.go
+++ b/useragent_decoder_test.go
@@ -75,7 +75,7 @@ func TestAgentParse(t *testing.T) {
 	var result string
 	for _, v := range []int{0, 10} {
 		decoder := buildDecoder(v)
-		agent := decoder.GetAgent(agentStr)
+		agent, _ := decoder.GetAgent(agentStr)
 
 		expected = "Mobile Safari"
 		if result = agent.UserAgent.Family; expected != result {
@@ -105,6 +105,26 @@ func TestAgentParse(t *testing.T) {
 		if result = agent.Device.Family; expected != result {
 			t.Errorf("incorrect device family; expected '%s', got '%s'", expected, result)
 		}
+	}
+}
+
+func TestAgentCached(t *testing.T) {
+	agent := "fooo"
+	decoder := buildDecoder(10)
+
+	if _, cached := decoder.GetAgent(agent); cached != false {
+		t.Error("expected cache miss but got a hit")
+	}
+	if _, cached := decoder.GetAgent(agent); cached != true {
+		t.Error("expected cache hit but got a miss")
+	}
+
+	decoder = buildDecoder(0)
+	if _, cached := decoder.GetAgent(agent); cached != false {
+		t.Error("expected cache miss but got a hit")
+	}
+	if _, cached := decoder.GetAgent(agent); cached != false {
+		t.Error("expected cache miss but got a hit")
 	}
 }
 

--- a/useragent_decoder_test.go
+++ b/useragent_decoder_test.go
@@ -38,6 +38,49 @@ func buildDecoder() *UserAgentDecoder {
 	return decoder
 }
 
+func TestAgentParse(t *testing.T) {
+	// NOTE This is intentionally non-exhaustive as the upstream uaparser
+	// library has plenty of tests that verify the parsing.
+	agentStr := "Mozilla/5.0 (iPhone; CPU iPhone OS 9_1 like Mac OS X) AppleWebKit/601.1.46 (KHTML, like Gecko) Version/9.0 Mobile/13B143 Safari/601.1"
+	decoder := buildDecoder()
+
+	agent := decoder.GetAgent(agentStr)
+	var expected string
+	var result string
+
+	expected = "Mobile Safari"
+	if result = agent.UserAgent.Family; expected != result {
+		t.Errorf("incorrect user agent family; expected '%s', got '%s'", expected, result)
+	}
+	expected = "9"
+	if result = agent.UserAgent.Major; expected != result {
+		t.Errorf("incorrect user agent major; expected '%s', got '%s'", expected, result)
+	}
+	expected = "0"
+	if result = agent.UserAgent.Minor; expected != result {
+		t.Errorf("incorrect user agent minor; expected '%s', got '%s'", expected, result)
+	}
+	expected = "iOS"
+	if result = agent.Os.Family; expected != result {
+		t.Errorf("incorrect os family; expected '%s', got '%s'", expected, result)
+	}
+	expected = "9"
+	if result = agent.Os.Major; expected != result {
+		t.Errorf("incorrect os major; expected '%s', got '%s'", expected, result)
+	}
+	expected = "1"
+	if result = agent.Os.Minor; expected != result {
+		t.Errorf("incorrect os minor; expected '%s', got '%s'", expected, result)
+	}
+	expected = "iPhone"
+	if result = agent.Device.Family; expected != result {
+		t.Errorf("incorrect device family; expected '%s', got '%s'", expected, result)
+	}
+}
+
+// TODO Add tests that verify the Heka message pack
+// TODO Add tests that verify long version name of the OS (i.e the field ua_os)
+
 func BenchmarkAgentParse(b *testing.B) {
 	decoder := buildDecoder()
 


### PR DESCRIPTION
Add a LRU cache to try and reduce the amount of costly re-parsing of user agents. We use a 2Q based LRU which tracks how recently an item was accessed as well as tracking how frequently an item was accessed.

This PR also adds some basic tests as well as some additional benchmarks to test the effectiveness of the cache.

```
$ go test -bench .          
PASS
BenchmarkAgentParse-8               	    1000	   2295191 ns/op
BenchmarkAgentParse50PercentCache-8 	    1000	   1164954 ns/op
BenchmarkAgentParse90PercentCache-8 	    5000	    296363 ns/op
BenchmarkAgentParse100PercentCache-8	 5000000	       266 ns/op
BenchmarkRealAgentParse-8           	     500	   2567106 ns/op
BenchmarkBadAgentParse-8            	    1000	   1607991 ns/op
ok  	_/Users/andrew/source/heka-useragent	12.388s
```

In my tests, assuming you are able to cache about 90% of your sample set, you can increase your performance by 85-90% compared to having no cache at all.